### PR TITLE
Added lean version specification

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,3 +1,4 @@
 [package]
 name = "saturn"
 version = "0.1"
+lean_version = "leanprover/lean4:4.0.0-m2"


### PR DESCRIPTION
This specifies the version of LEAN4 used by this project. It seems to solve the compatibility issues with the nightly release. 

Unforturnately, with the stable release of LEAN4, VS Code sometimes throws the following error - `Watchdog error: Got unknown document URI (file:///filename)` when multiple `.lean` files are opened in the same editor window. One workaround is to open only one file at a time in VS Code. This issue [has been fixed in a recent nightly release](https://leanprover-community.github.io/archive/stream/270676-lean4/topic/vscode-lean4.20Doesn't.20Work.20When.20I.20Switch.20Files.html).