### PR TITLE
Vectorize: avoiding functions in parameters passed on to avoid recomputation

### DIFF
--- a/Saturn/DPLL.lean
+++ b/Saturn/DPLL.lean
@@ -104,9 +104,9 @@ def restrictionData{dom n: Nat}(branch: Bool)(focus: Nat)(focusLt : focus < n + 
         RestrictionData branch focus focusLt clauses := 
         fun clauses =>
           let rc : RestrictionClauses branch focus focusLt Vector.Nil := 
-              ⟨zero, Vector.Nil, 
+              ⟨zero, Vector.Nil, Vector.Nil,
                 fun k w => nomatch w, 
-                fun k w => nomatch w, fun k w => nomatch w, fun k w => nomatch w⟩
+                Vector.Nil, fun k w => nomatch w⟩
           let rd : RestrictionData branch focus focusLt Vector.Nil := ⟨rc,
             ⟨fun k w => nomatch w⟩,
             ⟨fun k w => nomatch w⟩,

--- a/Saturn/FinSeq.lean
+++ b/Saturn/FinSeq.lean
@@ -985,10 +985,10 @@ theorem seqVecConsEqn {α: Type}{n : Nat} (seq : FinSeq (n + 1) α) :
           seqVec seq  = (head seq) +: (seqVec (tail seq)) := 
                   seqVecConsAux _ seq Vector.Nil
 
-def FinSeq.vec {α : Type}{n: Nat} : FinSeq n α  →  Vector α n := 
-  match n with
-  | zero => fun _ => Vector.Nil
-  | m + 1 => fun seq => Cons (head seq) (vec (tail seq))
+def FinSeq.vec {α : Type}{n: Nat} : FinSeq n α  →  Vector α n := seqVec
+  -- match n with
+  -- | zero => fun _ => Vector.Nil
+  -- | m + 1 => fun seq => Cons (head seq) (vec (tail seq))
 
 
 def equalCoords{α: Type}{n : Nat}{v1 v2 : Vector α n}: 
@@ -1041,7 +1041,7 @@ theorem seqAt{α : Type}{n : Nat}: (seq: FinSeq n α) →   seq.vec.at = seq :=
     | zero =>
       apply funext
       intro kw 
-      have resolve : seq.vec = Cons (head seq) (FinSeq.vec (tail seq)) by rfl 
+      have resolve : seq.vec = Cons (head seq) (FinSeq.vec (tail seq)) by apply seqVecConsEqn 
       rw resolve
       have res2 : Vector.at (head seq+:FinSeq.vec (tail seq)) zero kw = head seq by rfl
       rw res2
@@ -1051,7 +1051,11 @@ theorem seqAt{α : Type}{n : Nat}: (seq: FinSeq n α) →   seq.vec.at = seq :=
       apply funext
       intro kw
       have tl :Vector.at (FinSeq.vec seq) (succ k') kw = 
-          Vector.at (FinSeq.vec (tail seq)) k' (Nat.succ_lt_succ kw) by rfl 
+          Vector.at (FinSeq.vec (tail seq)) k' (Nat.succ_lt_succ kw) by
+              have dfn : FinSeq.vec seq = seqVec seq by rfl
+              rw dfn
+              rw (seqVecConsEqn seq) 
+              rfl 
       let base := seqAt (tail seq)
       rw tl
       rw base

--- a/Saturn/FinSeq.lean
+++ b/Saturn/FinSeq.lean
@@ -960,6 +960,14 @@ theorem consCommutes{α : Type}{n : Nat} (head : α) (tail : Vector α n) :
               intro kw
               rfl
 
+theorem tailCommutes{α : Type}{n : Nat} (x : α) (ys : Vector α n) :
+      tail (Vector.at (x +: ys)) = ys.at := 
+        by
+        apply funext
+        intro kw
+        rfl 
+        done
+
 def Vector.map {α β : Type}{n: Nat}(vec: Vector α n) (f : α → β) : Vector β n :=
     FinSeq.vec (fun j jw => f (vec.at j jw))
 

--- a/Saturn/PrependClause.lean
+++ b/Saturn/PrependClause.lean
@@ -17,12 +17,35 @@ def prependClause{dom n: Nat}(branch: Bool)(focus: Nat)(focusLt : focus < n + 1)
             let codomN := rc.codom + 1
             let clausesN := head +: clauses
             let restClausesN := headImage +: rc.restClauses
+            let forwardVecN := (some zero) +: (rc.forwardVec.map (fun nop => nop.map (. + 1)) )
             let forwardN: (k : Nat) →  k < domN → Option Nat  := 
               fun k  => 
               match k with 
               | zero => fun _ => some zero
               | l + 1 => 
                 fun w : l + 1 < domN   =>  (rc.forward l (leOfSuccLeSucc w)).map (. + 1)
+            let forwardNEq : forwardVecN.at = forwardN := by
+                  apply funext
+                  intro j
+                  cases j with
+                  | zero => 
+                    apply funext
+                    intro jw
+                    rfl
+                  | succ i =>
+                    apply funext
+                    intro jw
+                    have tl :forwardVecN.at (succ i) jw = 
+                        tail forwardVecN.at i (Nat.leOfSuccLeSucc jw) := by rfl
+                    rw tl
+                    rw tailCommutes (some zero) (rc.forwardVec.map (fun nop => nop.map (. + 1)) )
+                    rw mapAt
+                    have fr : forwardN (succ i) jw = 
+                            (rc.forward i (leOfSuccLeSucc jw)).map (. + 1)
+                        by rfl
+                    rw fr
+                    rfl
+                    done
             let forwardWitN : (k: Nat) → (w: k < domN) → boundOpt codomN (forwardN k w) := 
               fun k  => 
               match k with 
@@ -43,11 +66,31 @@ def prependClause{dom n: Nat}(branch: Bool)(focus: Nat)(focusLt : focus < n + 1)
                     rw lem
                     exact lem2
                     done
+            let reverseVecN := zero +: (rc.reverseVec.map (. + 1))
             let reverseN : (k : Nat) →  k < codomN → Nat :=             
               fun k =>
               match k with
               | zero => fun _ => zero
               | l + 1 => fun w => (rc.reverse l w) + 1
+            let reverseNEq : reverseVecN.at = reverseN := by
+                  apply funext
+                  intro j
+                  cases j with
+                  | zero =>
+                    apply funext
+                    intro jw
+                    rfl
+                    done
+                  | succ i =>
+                    apply funext
+                    intro jw
+                    have tl :reverseVecN.at (succ i) jw =
+                        tail reverseVecN.at i (Nat.leOfSuccLeSucc jw) := by rfl
+                    rw tl
+                    rw tailCommutes zero (rc.reverseVec.map (. + 1))
+                    rw mapAt
+                    rfl
+                    done
             let reverseWitN : (k : Nat) → (w : k < codomN) → reverseN k w < domN :=
               fun k =>
               match k with
@@ -55,13 +98,13 @@ def prependClause{dom n: Nat}(branch: Bool)(focus: Nat)(focusLt : focus < n + 1)
               | l + 1 => fun w => 
                 rc.reverseWit l w
             RestrictionClauses.mk codomN restClausesN 
-                    (FinSeq.vec forwardN) 
+                    (forwardVecN) 
                     (by 
-                      rw seqAt
+                      rw forwardNEq
                       exact forwardWitN) 
-                    (FinSeq.vec reverseN)
+                    reverseVecN
                     (by 
-                      rw seqAt
+                      rw reverseNEq
                       exact reverseWitN)
 
 namespace PrependClause
@@ -89,7 +132,27 @@ def droppedProof{dom n: Nat}(branch: Bool)(focus: Nat)(focusLt : focus < n + 1)
                       let lem1 : rcN.forward (l + 1) w = 
                         (rc.forward l (leOfSuccLeSucc w)).map (. + 1)  := 
                           by 
-                          done
+                            have res1 : rcN.forward (l + 1) w = 
+                                rcN.forwardVec.at (l + 1) w by rfl
+                            have res2 : rc.forward l (leOfSuccLeSucc w) =
+                                rc.forwardVec.at l (leOfSuccLeSucc w) by rfl
+                            rw res1
+                            rw res2
+                            have res3 :rcN.forwardVec = 
+                              (some zero) +: (rc.forwardVec.map (fun nop => nop.map (. + 1)) ) by rfl
+                            rw res3
+                            have res4 :
+                                Vector.at ((some zero) +: 
+                                  (rc.forwardVec.map (fun nop => nop.map (. + 1)) )) (l + 1) w =
+                                tail (
+                                 Vector.at ((some zero) +: 
+                                  (rc.forwardVec.map (fun nop => nop.map (. + 1)) )) 
+                                ) l (Nat.leOfSuccLeSucc w) by rfl
+                            rw res4
+                            rw (tailCommutes 
+                                (some zero) (rc.forwardVec.map (fun nop => nop.map (. + 1)) ))
+                            rw mapAt
+                            done
                       let lem2 := Eq.trans (Eq.symm lem1) nw
                       let lem3 := mapNoneIsNone _ _ lem2
                       let lem4 := drc.dropped l (leOfSuccLeSucc w) lem3
@@ -139,7 +202,29 @@ def forwardRelation{dom n: Nat}(branch: Bool)(focus: Nat)(focusLt : focus < n + 
                 | l + 1 => 
                   fun w  => 
                     let lem1 : rcN.forward (l + 1) w = 
-                      (rc.forward l (leOfSuccLeSucc w)).map (. + 1) := by rfl
+                      (rc.forward l (leOfSuccLeSucc w)).map (. + 1) := 
+                        by 
+                        have res1 : rcN.forward (l + 1) w = 
+                                rcN.forwardVec.at (l + 1) w by rfl
+                        have res2 : rc.forward l (leOfSuccLeSucc w) =
+                                rc.forwardVec.at l (leOfSuccLeSucc w) by rfl
+                        rw res1
+                        rw res2
+                        have res3 :rcN.forwardVec = 
+                          (some zero) +: (rc.forwardVec.map (fun nop => nop.map (. + 1)) ) by rfl
+                        rw res3
+                        have res4 :
+                            Vector.at ((some zero) +: 
+                              (rc.forwardVec.map (fun nop => nop.map (. + 1)) )) (l + 1) w =
+                            tail (
+                              Vector.at ((some zero) +: 
+                              (rc.forwardVec.map (fun nop => nop.map (. + 1)) )) 
+                            ) l (Nat.leOfSuccLeSucc w) by rfl
+                        rw res4
+                        rw (tailCommutes 
+                            (some zero) (rc.forwardVec.map (fun nop => nop.map (. + 1)) ))
+                        rw mapAt
+                        done
                     if c : Option.isNone (rcN.forward (l + 1) w) then 
                       fun j sw jw => 
                         let lem2 : Option.isNone (rcN.forward (l + 1) w) = false 
@@ -152,14 +237,59 @@ def forwardRelation{dom n: Nat}(branch: Bool)(focus: Nat)(focusLt : focus < n + 
                       | zero =>
                         fun sw jw =>
                           let lem2 : (rc.forward l (leOfSuccLeSucc w)).map (. + 1) =
-                            some zero := sw
+                            some zero := by
+                            rw ← sw
+                            apply Eq.symm
+                            have res1 : rcN.forward (l + 1) w = 
+                                rcN.forwardVec.at (l + 1) w by rfl
+                            have res2 : rc.forward l (leOfSuccLeSucc w) =
+                                    rc.forwardVec.at l (leOfSuccLeSucc w) by rfl
+                            rw res1
+                            rw res2
+                            have res3 :rcN.forwardVec = 
+                              (some zero) +: (rc.forwardVec.map (fun nop => nop.map (. + 1)) ) by rfl
+                            rw res3
+                            have res4 :
+                                Vector.at ((some zero) +: 
+                                  (rc.forwardVec.map (fun nop => nop.map (. + 1)) )) (l + 1) w =
+                                tail (
+                                  Vector.at ((some zero) +: 
+                                  (rc.forwardVec.map (fun nop => nop.map (. + 1)) )) 
+                                ) l (Nat.leOfSuccLeSucc w) by rfl
+                            rw res4
+                            rw (tailCommutes 
+                                (some zero) (rc.forwardVec.map (fun nop => nop.map (. + 1)) ))
+                            rw mapAt
+                            done
                          let lem2  : False := mapPlusOneZero lem2
                          absurd lem2 (fun x => x)
                       | i + 1 =>
                         by
                           intros sw jw
                           let lem2 : (rc.forward l (leOfSuccLeSucc w)).map (. + 1) =
-                            some (i + 1) := sw
+                            some (i + 1) := by
+                            rw ← sw              
+                            have res1 : rcN.forward (l + 1) w = 
+                                rcN.forwardVec.at (l + 1) w by rfl
+                            have res2 : rc.forward l (leOfSuccLeSucc w) =
+                                    rc.forwardVec.at l (leOfSuccLeSucc w) by rfl
+                            rw res1
+                            rw res2
+                            have res3 :rcN.forwardVec = 
+                              (some zero) +: (rc.forwardVec.map (fun nop => nop.map (. + 1)) ) by rfl
+                            rw res3
+                            have res4 :
+                                Vector.at ((some zero) +: 
+                                  (rc.forwardVec.map (fun nop => nop.map (. + 1)) )) (l + 1) w =
+                                tail (
+                                  Vector.at ((some zero) +: 
+                                  (rc.forwardVec.map (fun nop => nop.map (. + 1)) )) 
+                                ) l (Nat.leOfSuccLeSucc w) by rfl
+                            rw res4
+                            rw (tailCommutes 
+                                (some zero) (rc.forwardVec.map (fun nop => nop.map (. + 1)) ))
+                            rw mapAt
+                            done
                           let lem3 : rc.forward l (leOfSuccLeSucc w) = some i 
                             := mapPlusOneShift lem2
                           let lem4 := 
@@ -212,9 +342,57 @@ def reverseRelation{dom n: Nat}(branch: Bool)(focus: Nat)(focusLt : focus < n + 
                               rc.restClauses.at l (leOfSuccLeSucc w) := by rfl
                         let lem2 := rrc.relation l (leOfSuccLeSucc w) 
                         by
-                          rw lem1
-                          
-                          exact lem2
+                          rw lem1                          
+                          rw lem2
+                          have res0 : rcN.reverse (l + 1) w =
+                               rc.reverse l (Nat.leOfSuccLeSucc w) + 1 := 
+                                by                                  
+                                  have res1 : rcN.reverse (l + 1) w = 
+                                      rcN.reverseVec.at (l + 1) w by rfl
+                                  have res2 : rc.reverse l (leOfSuccLeSucc w) =
+                                          rc.reverseVec.at l (leOfSuccLeSucc w) by rfl
+                                  rw res1
+                                  rw res2
+                                  have res3 :rcN.reverseVec = 
+                                    zero +: (rc.reverseVec.map (. + 1))  by rfl
+                                  rw res3
+                                  have res4 :
+                                      Vector.at (zero +: 
+                                        (rc.reverseVec.map (. + 1)) ) (l + 1) w =
+                                      tail (
+                                        Vector.at (zero +: 
+                                        (rc.reverseVec.map (. + 1)) ) 
+                                      ) l (Nat.leOfSuccLeSucc w) by rfl
+                                  rw res4
+                                  rw (tailCommutes 
+                                      zero (rc.reverseVec.map (. + 1)))
+                                  rw mapAt                                  
+                                  done
+                          have res00 : clausesN.at (rcN.reverse (l + 1) w) 
+                                  (rcN.reverseWit (l + 1) w) =
+                              clauses.at (rc.reverse l 
+                                (Nat.leOfSuccLeSucc w))
+                                (rc.reverseWit l 
+                                (Nat.leOfSuccLeSucc w)) by 
+                                  have rs0 : clausesN.at (rcN.reverse (l + 1) w) 
+                                    (rcN.reverseWit (l + 1) w) =
+                                      clausesN.at (rc.reverse l (Nat.leOfSuccLeSucc w) + 1)
+                                        (rc.reverseWit l (Nat.leOfSuccLeSucc w)) by 
+                                        apply witnessIndependent
+                                        exact res0
+                                        done
+                                  rw rs0
+                                  have dfn : clausesN = head +: clauses by rfl
+                                  rw dfn 
+                                  have td :
+                                    Vector.at (head +: clauses) 
+                                       (rc.reverse l (Nat.leOfSuccLeSucc w) + 1) 
+                                       (rc.reverseWit l (Nat.leOfSuccLeSucc w)) =
+                                        clauses.at (rc.reverse l (Nat.leOfSuccLeSucc w))
+                                          (rc.reverseWit l (Nat.leOfSuccLeSucc w)) by rfl
+                                  rw td
+                                  done
+                          rw res00                                
                           done
           ⟨relationN⟩
 
@@ -249,7 +427,58 @@ def pureReverse{dom n: Nat}(branch: Bool)(focus: Nat)(focusLt : focus < n + 1)
                         Vector.at (clausesN.at (rcN.reverse (l + 1) w) (rcN.reverseWit (l + 1) w)) 
                           focus focusLt =
                           Vector.at (clauses.at (rc.reverse l (leOfSuccLeSucc w)) 
-                            (rc.reverseWit l (leOfSuccLeSucc w))) focus focusLt := by rfl
+                            (rc.reverseWit l (leOfSuccLeSucc w))) focus focusLt := 
+                              by 
+                                have res0 : rcN.reverse (l + 1) w =
+                                  rc.reverse l (Nat.leOfSuccLeSucc w) + 1 := 
+                                    by                                  
+                                      have res1 : rcN.reverse (l + 1) w = 
+                                          rcN.reverseVec.at (l + 1) w by rfl
+                                      have res2 : rc.reverse l (leOfSuccLeSucc w) =
+                                              rc.reverseVec.at l (leOfSuccLeSucc w) by rfl
+                                      rw res1
+                                      rw res2
+                                      have res3 :rcN.reverseVec = 
+                                        zero +: (rc.reverseVec.map (. + 1))  by rfl
+                                      rw res3
+                                      have res4 :
+                                          Vector.at (zero +: 
+                                            (rc.reverseVec.map (. + 1)) ) (l + 1) w =
+                                          tail (
+                                            Vector.at (zero +: 
+                                            (rc.reverseVec.map (. + 1)) ) 
+                                          ) l (Nat.leOfSuccLeSucc w) by rfl
+                                      rw res4
+                                      rw (tailCommutes 
+                                          zero (rc.reverseVec.map (. + 1)))
+                                      rw mapAt                                  
+                                      done
+                                have res00 : clausesN.at (rcN.reverse (l + 1) w) 
+                                  (rcN.reverseWit (l + 1) w) =
+                                    clauses.at (rc.reverse l 
+                                      (Nat.leOfSuccLeSucc w))
+                                      (rc.reverseWit l 
+                                      (Nat.leOfSuccLeSucc w)) by 
+                                        have rs0 : clausesN.at (rcN.reverse (l + 1) w) 
+                                          (rcN.reverseWit (l + 1) w) =
+                                            clausesN.at (rc.reverse l (Nat.leOfSuccLeSucc w) + 1)
+                                              (rc.reverseWit l (Nat.leOfSuccLeSucc w)) by 
+                                              apply witnessIndependent
+                                              exact res0
+                                              done
+                                        rw rs0
+                                        have dfn : clausesN = head +: clauses by rfl
+                                        rw dfn 
+                                        have td :
+                                          Vector.at (head +: clauses) 
+                                            (rc.reverse l (Nat.leOfSuccLeSucc w) + 1) 
+                                            (rc.reverseWit l (Nat.leOfSuccLeSucc w)) =
+                                              clauses.at (rc.reverse l (Nat.leOfSuccLeSucc w))
+                                                (rc.reverseWit l (Nat.leOfSuccLeSucc w)) by rfl
+                                        rw td
+                                        done
+                                rw res00
+                                done
                     let lem2 := Eq.trans (Eq.symm lem) hyp
                     prc.nonPosRev l (leOfSuccLeSucc w) lem2
           ⟨pureN⟩

--- a/Saturn/PrependClause.lean
+++ b/Saturn/PrependClause.lean
@@ -54,7 +54,15 @@ def prependClause{dom n: Nat}(branch: Bool)(focus: Nat)(focusLt : focus < n + 1)
               | 0 => fun _ => zeroLtSucc _ 
               | l + 1 => fun w => 
                 rc.reverseWit l w
-            RestrictionClauses.mk codomN restClausesN forwardN forwardWitN reverseN reverseWitN
+            RestrictionClauses.mk codomN restClausesN 
+                    (FinSeq.vec forwardN) 
+                    (by 
+                      rw seqAt
+                      exact forwardWitN) 
+                    (FinSeq.vec reverseN)
+                    (by 
+                      rw seqAt
+                      exact reverseWitN)
 
 namespace PrependClause
 
@@ -79,7 +87,9 @@ def droppedProof{dom n: Nat}(branch: Bool)(focus: Nat)(focusLt : focus < n + 1)
                   | l + 1 => 
                     fun w nw =>
                       let lem1 : rcN.forward (l + 1) w = 
-                        (rc.forward l (leOfSuccLeSucc w)).map (. + 1)  := by rfl
+                        (rc.forward l (leOfSuccLeSucc w)).map (. + 1)  := 
+                          by 
+                          done
                       let lem2 := Eq.trans (Eq.symm lem1) nw
                       let lem3 := mapNoneIsNone _ _ lem2
                       let lem4 := drc.dropped l (leOfSuccLeSucc w) lem3
@@ -203,6 +213,7 @@ def reverseRelation{dom n: Nat}(branch: Bool)(focus: Nat)(focusLt : focus < n + 
                         let lem2 := rrc.relation l (leOfSuccLeSucc w) 
                         by
                           rw lem1
+                          
                           exact lem2
                           done
           ⟨relationN⟩

--- a/Saturn/Solverstep.lean
+++ b/Saturn/Solverstep.lean
@@ -60,11 +60,22 @@ structure RestrictionClauses{dom n: Nat}(branch: Bool)(focus: Nat)(focusLt : foc
     (clauses: Vector (Clause (n + 1)) dom) where
   codom : Nat
   restClauses : Vector  (Clause n) codom
-  forward : (k: Nat) → k < dom → Option Nat
-  forwardWit : (k: Nat) → (w: k < dom) → boundOpt codom (forward k w)
-  reverse : (k : Nat) → (k < codom) → Nat
-  reverseWit : (k : Nat) → (w : k < codom) → reverse k w < dom
+  forwardVec : Vector (Option Nat) dom
+  forwardWit : (k: Nat) → (w: k < dom) → boundOpt codom (forwardVec.at k w)
+  reverseVec : Vector Nat codom
+  reverseWit : (k : Nat) → (w : k < codom) → reverseVec.at k w < dom
   
+def RestrictionClauses.forward{dom n: Nat}{branch: Bool}{focus: Nat}{focusLt : focus < n + 1}
+    {clauses: Vector (Clause (n + 1)) dom}
+      (rc: RestrictionClauses branch focus focusLt clauses) :
+        (j: Nat) → (jw : j < dom) → Option Nat := rc.forwardVec.at
+
+def RestrictionClauses.reverse{dom n: Nat}{branch: Bool}{focus: Nat}{focusLt : focus < n + 1}
+    {clauses: Vector (Clause (n + 1)) dom}
+      (rc: RestrictionClauses branch focus focusLt clauses) :
+        (j: Nat) → (jw : j < rc.codom) → Nat := rc.reverseVec.at
+
+
 structure DroppedProof{dom n: Nat}{branch: Bool}{focus: Nat}{focusLt : focus < n + 1}
     {clauses: Vector (Clause (n + 1)) dom}(
         rc: RestrictionClauses branch focus focusLt clauses)  where


### PR DESCRIPTION
The performance actually worsens, so it is not clear if these changes should be made. At least it should be as a single, easy to revert, commit